### PR TITLE
Fix use after free when dropping the last process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,11 @@ impl<T> Drop for Process<T> {
             if (*self.owner).processes == 0 {
                 let dekker = Box::from_raw(self.owner);
                 drop(dekker);
+                std::mem::forget(guard);
+            } else {
+                drop(guard);
             }
         }
-
-        drop(guard);
     }
 }
 


### PR DESCRIPTION
Guards modify the Dekker that they're guarding on drop, so in the Drop
of a Process, when we create a Guard we need to ensure that if the
Dekker is deallocated, we also do not let the Drop impl for the Guard
run.